### PR TITLE
Small update to get-links

### DIFF
--- a/src/query.lisp
+++ b/src/query.lisp
@@ -311,7 +311,7 @@ which is the rvstart id to pass in the next call to get more results.
 	   (prop links))
     :req (titles)
     :props ((pllimit 5000) 
-;	    plnamespace  ;; UNIMPLEMENTED
+	    (plnamespace nil)
 	    plcontinue)
     :processor
     (lambda (sxml)
@@ -329,7 +329,8 @@ Parameters:
   titles         - the title of the page we wish to retrieve the info of
   pllimit        - How many links to return. Default: 10. No more than 500 (5000 for bots) allowed.
   plcontinue     - When more results are available, use this to continue.
-  plnamespace    - Only list links to pages in these namespaces. (NOT IMPLEMENTED)
+  plnamespace    - Only list links to pages in these namespaces.
+                   (For example, set plnamespace to 0 to get only article links in Wikipedia.)
 
 Examples: 
   ; gets 10 results


### PR DESCRIPTION
Hi Russ,

Never mind my email -- it's probably easier just to switch to github right now. This commit is just a very small change which enables get-links to specify the namespace, which is useful for instance for pulling only article links in Wikipedia.

I'm not bothering sticking this on a topic branch since it seems like overkill, but let me know if you have a preferred workflow for the future.
