### PR TITLE
Leave *mediawiki* unbound by default

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -4,8 +4,9 @@
    (auth :accessor auth :initarg :auth :initform nil)
    (cookie-jar :accessor cookie-jar :initarg cookie-jar :initform (make-instance 'drakma:cookie-jar))))
 
-(defvar *mediawiki* nil
-  "the current instance of media wiki we are dealing with (mostly for use with with-mediawiki)")
+(defvar *mediawiki*)
+(setf (documentation '*mediawiki* 'variable)
+      "the current instance of media wiki we are dealing with (mostly for use with with-mediawiki)")
 
 (defmacro with-mediawiki ((obj) &body body)
   `(let ((*mediawiki* ,(typecase obj


### PR DESCRIPTION
This presents the user a more clear error message when calling the API without binding *mediawiki* first.

For example if a user `(get-page-content "Pigment")` previously he would see
if

```
There is no applicable method for the generic function
  #<STANDARD-GENERIC-FUNCTION
    NET.ACCELERATION.CL-MEDIAWIKI::AUTH (1)>
when called with arguments
  (NIL).
   [Condition of type SIMPLE-ERROR]
```

from the default value for the `basic-authorization` keyword arguments from make-api-request, which calls (auth *mediawiki*). If `*mediawiki*` is left unbound,

```
The variable *MEDIAWIKI* is unbound.
   [Condition of type UNBOUND-VARIABLE]
```

Btw, the test system tries to bind `lisp-unit:*print-failures*` but there is no symbol by that name in that package.