### PR TITLE
Migrate test suite to lisp-unit2

### DIFF
--- a/cl-mediawiki-test.asd
+++ b/cl-mediawiki-test.asd
@@ -1,0 +1,12 @@
+(in-package #:asdf-user)
+
+(defsystem :cl-mediawiki-test
+  :description "The test suite for the cl-mediawiki system."
+  :components ((:module :tests
+                        :serial T
+                        :components ((:file "setup")
+                                     (:file "query" )
+                                     (:file "edit"))))
+  ;; Additional Functionality will be loaded if cl-ppcre is in
+  ;; the features list during compilation
+  :depends-on (:cl-mediawiki :lisp-unit2))

--- a/cl-mediawiki.asd
+++ b/cl-mediawiki.asd
@@ -18,20 +18,8 @@
                                      (:file "edit"))))
   ;; Additional Functionality will be loaded if cl-ppcre is in
   ;; the features list during compilation
-  :depends-on (:cxml :drakma :alexandria))
-
-(defsystem :cl-mediawiki-test
-  :description "A tool to help talk to mediawiki's api."
-  :components ((:module :tests
-                        :serial T
-                        :components ((:file "setup")
-                                     (:file "query" )
-                                     (:file "edit"))))
-  ;; Additional Functionality will be loaded if cl-ppcre is in
-  ;; the features list during compilation
-  :depends-on (:cl-mediawiki :lisp-unit))
-
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :cl-mediawiki))))
-  (asdf:oos 'asdf:load-op :cl-mediawiki-test)
-  (funcall (intern "RUN-TESTS" :cl-mediawiki-test)
-           :use-debugger nil))
+  :depends-on (:cxml :drakma :alexandria)
+  :in-order-to ((test-op (asdf:load-op :cl-mediawiki-test)))
+  :perform (test-op (o c)
+                    (uiop:symbol-call :lisp-unit2 'run-tests
+                                      :package :cl-mediawiki-test)))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -14,6 +14,9 @@
      ,@body
      ))
 
+(defvar *default-external-format* :utf-8
+  "sets as the drakma default coding system")
+
 (defun make-api-request (api-params &key (basic-authorization (auth *mediawiki* )) (force-ssl nil force-ssl-p) (method :get))
   "Calls the media wiki api providing the specified parameters"
   ;; force-ssl should either be whats passed in, or if nothing is passed in
@@ -38,9 +41,6 @@
 ;;      (format *debug-io* "~&uri == ~S" uri) ; debugging
       (declare (ignore headers uri stream must-close status-word))
       (values content status))))
-
-(defvar *default-external-format* :utf-8
-  "sets as the drakma default coding system")
 
 (defun make-parameters (params)
   "Takes a list of bindings (:key :val) and prepares them for transit

--- a/tests/query.lisp
+++ b/tests/query.lisp
@@ -1,31 +1,31 @@
 (in-package :cl-mediawiki-test)
 
-(def-test-wikipedia get-content-test (query)
+(define-wikipedia-test get-content-test ()
   (assert-true
    (cl-mediawiki:get-page-content "Pigment")))
 
-(def-test-wikipedia get-action-tokens-test (query)
+(define-wikipedia-test get-action-tokens-test ()
   (assert-true
       (cl-mediawiki:get-action-tokens "Pigment")))
 
-(def-test-wikipedia pages-that-embed-test (query)
+(define-wikipedia-test pages-that-embed-test ()
   (assert-false
       (cl-mediawiki:pages-that-embed "Pigment"))
   (assert-true
       (cl-mediawiki:pages-that-embed "Template:Grateful_Dead" )))
 
-(def-test-wikipedia get-page-info-test (query)
+(define-wikipedia-test get-page-info-test ()
   (assert-true
       (cl-mediawiki:get-page-info "Pigment" )))
 
-(def-test-wikipedia recent-changes-test (query)
+(define-wikipedia-test recent-changes-test ()
   (assert-true
       (cl-mediawiki:recent-changes)))
 
-(def-test-wikipedia user-contribs-test (query)
+(define-wikipedia-test user-contribs-test ()
   (assert-true
       (cl-mediawiki:user-contribs "bobbysmith007")))
 
-(def-test-wikipedia get-revisions-test (query)
+(define-wikipedia-test get-revisions-test ()
   (assert-true
       (cl-mediawiki:get-revisions "Pigment" :rvlimit 10)))

--- a/tests/setup.lisp
+++ b/tests/setup.lisp
@@ -1,68 +1,10 @@
-
 (defpackage :net.acceleration.cl-mediawiki-test
-    (:nicknames #:cl-mediawiki-test)
-  (:use :common-lisp :cxml :lisp-unit :cl-mediawiki)
-  (:shadow :cdata :run-tests))
+  (:nicknames #:cl-mediawiki-test)
+  (:use :common-lisp #:lisp-unit2))
 
 (in-package :cl-mediawiki-test)
 
-(defun log-time (&optional (time (get-universal-time)) stream)
-  "returns a date as ${mon}/${d}/${y} ${h}:${min}:{s}, defaults to get-universal-time"
-  (multiple-value-bind ( s min h  )
-      (decode-universal-time time)
-    (format stream "~2,'0d:~2,'0d:~2,'0d "  h min s)))
-
-(defun cl-mediawiki-tests.info (message &rest args)
-  (format *standard-output* "~&")
-  (log-time (get-universal-time) *standard-output*)
-  (apply #'format *standard-output* message args)
-  (format *standard-output* "~%"))
-
-;; make everythign in cl-mediawiki accessible here
-(with-package-iterator (sym '(:cl-mediawiki) :internal :external)
-  (let (more? symbol accessibility pkg)
-    (loop do (multiple-value-setq (more? symbol accessibility pkg) (sym))
-
-             (when (eql (find-package :cl-mediawiki)
-                        pkg)
-               (ignore-errors
-                 (unintern symbol :cl-mediawiki-test)
-                 (import (list symbol) :cl-mediawiki-test)))
-          while more?
-          )))
-
-(defmacro def-test (name (&rest args) &body body)
-  (loop for tag in args
-        do (setf (get tag :tests)
-                 (union (alexandria:ensure-list (get tag :tests))
-                        (list name))))
-  `(lisp-unit:define-test ,name
-     (progn
-       ,@body
-       )))
-
-(defmacro def-test-wikipedia (name (&rest args) &body body)
-  `(def-test ,name (,@args)
+(defmacro define-wikipedia-test (name () &body body)
+  `(lisp-unit2:define-test ,name ()
      (cl-mediawiki:with-mediawiki ("http://en.wikipedia.org/w")
-       ,@body
-       )))
-
-(defun run-tests (&key suites tests (use-debugger T))
-  (let* ((*package* (find-package :buildnode-test))
-         (lisp-unit:*print-failures* t)
-         (lisp-unit:*print-errors* t)
-         (lisp-unit::*use-debugger* use-debugger)
-         (tests (append (alexandria:ensure-list tests)
-                        (loop for suite in (alexandria:ensure-list suites)
-                              appending (get suite :tests))))
-         (actual-std-out *standard-output*)
-         (out (with-output-to-string (s)
-                (let ((*standard-output*
-                        (make-broadcast-stream s actual-std-out)))
-                  (if (null tests)
-                      (lisp-unit::%run-all-thunks)
-                      (lisp-unit::%run-thunks tests))))))
-    (format *standard-output*
-     "~&~% ** TEST RESULTS: CL-MEDIAWIKI ** ~%-----------~%~A~%------ END TEST RESULTS ------~%"
-     out)))
-
+       ,@body)))


### PR DESCRIPTION
The only loss of functionality is the removed all the timing reports in the test suite. I also polished the ASDF definition a little bit. I assumed that lisp-unit2 is the test framework of your preference.