### PR TITLE
Have WITH-MEDIAWIKI properly evaluate its argument

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -8,12 +8,14 @@
 (setf (documentation '*mediawiki* 'variable)
       "the current instance of media wiki we are dealing with (mostly for use with with-mediawiki)")
 
+(defun ensure-mediawiki (obj)
+  (etypecase obj
+    (string (make-instance 'mediawiki :url obj))
+    (mediawiki obj)))
+
 (defmacro with-mediawiki ((obj) &body body)
-  `(let ((*mediawiki* ,(typecase obj
-                         (string `(make-instance 'mediawiki :url ,obj))
-                         (T obj))))
-     ,@body
-     ))
+  `(let ((*mediawiki* (ensure-mediawiki ,obj)))
+     ,@body))
 
 (defvar *default-external-format* :utf-8
   "sets as the drakma default coding system")


### PR DESCRIPTION
Adds a function that checks the type of the passed object at runtime
rather than at macroexpansion time and then modifies the macro to
generate a call to this function.  This way, if the url of the mediawiki
site is being computed, it won't misinterpret the form that generates
the url as the instance of mediawiki to be worked with.
